### PR TITLE
Add XML for ttbar files

### DIFF
--- a/config/MTopJetPreSelection.xml
+++ b/config/MTopJetPreSelection.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 <!ENTITY NEVT "100">
+<!-- JERC -->
+<!ENTITY JECSMEAR_DIRECTION         "nominal">  <!--nominal/down/up -->
+<!ENTITY JERSMEAR_DIRECTION         "nominal">  <!--nominal/down/up -->
 
 <!ENTITY OUTdir  "/nfs/dust/cms/user/paaschal/sframe_all/MTopJet/presel">
 
@@ -84,3 +87,7 @@
 
   </Cycle>
 </JobConfiguration>
+    <!-- JERC -->
+    <!--used only in UHH2/common/include/JetCorrections.cxx -->
+    <Item Name="jecsmear_direction"             Value="&JECSMEAR_DIRECTION;"/>
+    <Item Name="jersmear_direction"             Value="&JERSMEAR_DIRECTION;"/>

--- a/config/MTopJetPreSelection.xml
+++ b/config/MTopJetPreSelection.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
+<!ENTITY NEVT "100">
+
+<!ENTITY OUTdir  "/nfs/dust/cms/user/paaschal/sframe_all/MTopJet/presel">
+
+<!-- Lumi Values are not changed in outcomment Files!!!! -->
+
+<!-- ================================================================================================================================ -->
+<!-- =============================================== MC ============================================================================= -->
+
+<!ENTITY TTTo2L2Nu_Mtt0000to0700         SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/SM/UL18/TTTo2L2Nu_CP5_powheg-pythia8_Summer20UL18_v1.xml">
+<!ENTITY TTToSemiLeptonic_Mtt0000to0700  SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/SM/UL18/TTToSemiLeptonic_CP5_powheg-pythia8_Summer20UL18_v2.xml">
+<!ENTITY TTToHadronic_Mtt0000to0700      SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/SM/UL18/TTToHadronic_CP5_powheg-pythia8_Summer20UL18_v1.xml">
+<!ENTITY TT_Mtt0700to1000                SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/SM/UL18/TT_Mtt-1000toInf_CP5_powheg-pythia8_Summer20UL18_v1.xml">
+<!ENTITY TT_Mtt1000toInft                SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/SM/UL18/TT_Mtt-700to1000_CP5_powheg-pythia8_Summer20UL18_v2.xml">
+
+
+]>
+
+<!-- ================================================================================================================================== -->
+<!-- =============================================== SFrame Batch ===================================================================== -->
+<!-- ================================================================================================================================== -->
+
+<!--
+   <ConfigParse NEventsBreak="0" LastBreak="0" FileSplit="100" />
+   <ConfigSGE RAM ="4" DISK ="2" Mail="dennis.schwarz@desy.de" Notification="as" Workdir="Workdir_PreSel_2018"/>
+-->
+
+<JobConfiguration JobName="MTopJetPreSelectionJob" OutputLevel="INFO">
+    <Library Name="libSUHH2MTopJet"/>
+    <Package Name="SUHH2MTopJet.par"/>
+
+ <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="59740">
+
+<!-- ================================================================================================================================== -->
+<!-- ================================================================================================================================== -->
+
+    <!-- <InputData Version="TTbar_2L2Nu_Mtt0000to0700_2018" Lumi="12406354.39" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
+    &TTTo2L2Nu_Mtt0000to0700; <InputTree Name="AnalysisTree"/> <OutputTree Name="AnalysisTree"/> </InputData> -->
+
+    <InputData Version="TTbar_SemiLeptonic_Mtt0000to0700_2018" Lumi="169042554.76" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
+    &TTToSemiLeptonic_Mtt0000to0700; <InputTree Name="AnalysisTree"/> <OutputTree Name="AnalysisTree"/> </InputData>
+
+    <!-- <InputData Version="TTbar_Hadronic_Mtt0000to0700_2018" Lumi="126708342.91" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
+    &TTToHadronic_Mtt0000to0700; <InputTree Name="AnalysisTree"/> <OutputTree Name="AnalysisTree"/> </InputData>
+
+    <InputData Version="TTbar_Mtt0700to1000_2018" Lumi="311904071.33" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
+    &TT_Mtt0700to1000; <InputTree Name="AnalysisTree"/> <OutputTree Name="AnalysisTree"/> </InputData>
+
+    <InputData Version="TTbar_Mtt1000toInft_2018" Lumi="918549952.59" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
+    &TT_Mtt1000toInft; <InputTree Name="AnalysisTree"/> <OutputTree Name="AnalysisTree"/> </InputData> -->
+
+<!-- ================================================================================================================================== -->
+<!-- ====================================================== User Config =============================================================== -->
+<!-- ================================================================================================================================== -->
+
+  <UserConfig>
+    <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices"/>
+    <Item Name="GenParticleCollection"   Value="GenParticles"/>
+    <Item Name="ElectronCollection"      Value="slimmedElectronsUSER"/>
+    <Item Name="MuonCollection"          Value="slimmedMuonsUSER"/>
+
+    <Item Name="JetCollection"           Value="jetsAk4CHS"/>
+    <Item Name="GenJetCollection"        Value="slimmedGenJets"/>
+    <Item Name="TopJetCollection"        Value="jetsAk8CHSSubstructure_SoftDropCHS"/>
+    <Item Name="GenTopJetCollection"     Value="genjetsAk8SubstructureSoftDrop" />
+
+	<Item Name="additionalBranches" Value="xconeCHS xconePuppi genXCone33TopJets genXCone33TopJets_softdrop genjetsAk8Substructure"/>
+
+
+    <!--        <Item Name="METName"                 Value="slimmedMETsNoHF"/> -->
+    <Item Name="METName"                 Value="slimmedMETs"/>
+
+    <Item Name="lumi_file" Value="../../common/UHH2-data/UL18/Cert_314472-325175_13TeV_Legacy2018_Collisions18_JSON_normtag.root"/>
+    <Item Name="lumihists_lumi_per_bin" Value="250"/>
+
+    <!-- if use_sframe_weight is set to 'false' the weight is changed according to the lumi -->
+    <Item Name="use_sframe_weight" Value="false"/> <!-- this does nothing becaus common modules is not called in the AnalysisModule -->
+
+    <Item Name="AnalysisModule" Value="MTopJetModule"/>
+
+  </UserConfig>
+
+  </Cycle>
+</JobConfiguration>

--- a/config/MTopJetPreSelection.xml
+++ b/config/MTopJetPreSelection.xml
@@ -115,7 +115,3 @@
 
   </Cycle>
 </JobConfiguration>
-    <!-- JERC -->
-    <!--used only in UHH2/common/include/JetCorrections.cxx -->
-    <Item Name="jecsmear_direction"             Value="&JECSMEAR_DIRECTION;"/>
-    <Item Name="jersmear_direction"             Value="&JERSMEAR_DIRECTION;"/>

--- a/config/MTopJetPreSelection.xml
+++ b/config/MTopJetPreSelection.xml
@@ -11,6 +11,14 @@
 <!ENTITY OUTdir   "/nfs/dust/cms/user/paaschal/sframe_all/MTopJet/presel">
 <!ENTITY DEBUG    "false">
 
+<!-- MC PuReweighting -->
+<!ENTITY DO_PU_REWEIGHTING          "true">     <!-- true, false -->
+<!ENTITY SYSTYPE_PU                 "central">  <!-- central, up, down -->
+<!ENTITY PILEUP_DIRECTORY           "&BASEdir;common/UHH2-data/UL18/MyMCPileupHistogram_UL18.root">
+<!ENTITY PILEUP_DIRECTORY_DATA      "&BASEdir;common/UHH2-data/UL18/MyDataPileupHistogram_UL18.root">
+<!ENTITY PILEUP_DIRECTORY_DATA_UP   "&BASEdir;common/UHH2-data/UL18/MyDataPileupHistogram_UL18_72383.root">
+<!ENTITY PILEUP_DIRECTORY_DATA_DOWN "&BASEdir;common/UHH2-data/UL18/MyDataPileupHistogram_UL18_66017.root">
+
 <!-- Lumi Values are not changed in outcomment Files!!!! -->
 
 <!-- ================================================================================================================================ -->
@@ -89,6 +97,14 @@
     <!--used only in UHH2/common/include/JetCorrections.cxx -->
     <Item Name="jecsmear_direction"             Value="&JECSMEAR_DIRECTION;"/>
     <Item Name="jersmear_direction"             Value="&JERSMEAR_DIRECTION;"/>
+
+    <!-- MC PuReweighting -->
+    <Item Name="DO_Pu_ReWeighting"              Value="&DO_PU_REWEIGHTING;"/>
+    <Item Name="SysType_PU"                     Value="&SYSTYPE_PU;"/>
+    <Item Name="pileup_directory"               Value="&PILEUP_DIRECTORY;"/>            <!--used only in UHH2/common/include/MCWeight.h -->
+    <Item Name="pileup_directory_data"          Value="&PILEUP_DIRECTORY_DATA;"/>       <!--used only in UHH2/common/include/MCWeight.h -->
+    <Item Name="pileup_directory_data_up"       Value="&PILEUP_DIRECTORY_DATA_UP;"/>    <!--used only in UHH2/common/include/MCWeight.h -->
+    <Item Name="pileup_directory_data_down"     Value="&PILEUP_DIRECTORY_DATA_DOWN;"/>  <!--used only in UHH2/common/include/MCWeight.h -->
 
     <!-- MC PuReweighting -->
     <Item Name="Debug" Value="&DEBUG;" />

--- a/config/MTopJetPreSelection.xml
+++ b/config/MTopJetPreSelection.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 <!ENTITY NEVT "100">
+
 <!-- JERC -->
 <!ENTITY JECSMEAR_DIRECTION         "nominal">  <!--nominal/down/up -->
 <!ENTITY JERSMEAR_DIRECTION         "nominal">  <!--nominal/down/up -->
 
-<!ENTITY OUTdir  "/nfs/dust/cms/user/paaschal/sframe_all/MTopJet/presel">
+<!-- USER based variables -->
+<!ENTITY BASEdir  "/nfs/dust/cms/user/paaschal/WorkingArea/Analysis/MTopJet/UHH2_MTopJet_UL/CMSSW_10_6_28/src/UHH2/">
+<!ENTITY OUTdir   "/nfs/dust/cms/user/paaschal/sframe_all/MTopJet/presel">
+<!ENTITY DEBUG    "false">
 
 <!-- Lumi Values are not changed in outcomment Files!!!! -->
 
@@ -80,6 +84,14 @@
 
     <!-- if use_sframe_weight is set to 'false' the weight is changed according to the lumi -->
     <Item Name="use_sframe_weight" Value="false"/> <!-- this does nothing becaus common modules is not called in the AnalysisModule -->
+
+    <!-- JERC -->
+    <!--used only in UHH2/common/include/JetCorrections.cxx -->
+    <Item Name="jecsmear_direction"             Value="&JECSMEAR_DIRECTION;"/>
+    <Item Name="jersmear_direction"             Value="&JERSMEAR_DIRECTION;"/>
+
+    <!-- MC PuReweighting -->
+    <Item Name="Debug" Value="&DEBUG;" />
 
     <Item Name="AnalysisModule" Value="MTopJetModule"/>
 

--- a/src/MTopJetModule.cxx
+++ b/src/MTopJetModule.cxx
@@ -40,9 +40,11 @@ private:
     // store the Hists collection as member variables. Again, use unique_ptr to avoid memory leaks.
     std::unique_ptr<Hists> h_nocuts, h_njet, h_dijet, h_ele;
 
-
     // bools
     bool isMC;
+
+    // store Hist collection as member variables
+    std::unique_ptr<Hists> h_ttbar;
 };
 
 


### PR DESCRIPTION
Basis for ttbar XML files. Add lumifile, all ttbar samples, the PU and certain user variables e.g. debugging.
Code runs up to the constructor of the Analysis Module. further adjustments are necessary to the process running e.g. to setup the year correctly in `event.year`.