### PR TITLE
dataset version to UL

### DIFF
--- a/config/MTopJetPreSelection.xml
+++ b/config/MTopJetPreSelection.xml
@@ -51,19 +51,19 @@
 <!-- ================================================================================================================================== -->
 <!-- ================================================================================================================================== -->
 
-    <!-- <InputData Version="TTbar_2L2Nu_Mtt0000to0700_2018" Lumi="12406354.39" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
+    <!-- <InputData Version="TTbar_2L2Nu_Mtt0000to0700_UL18" Lumi="12406354.39" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
     &TTTo2L2Nu_Mtt0000to0700; <InputTree Name="AnalysisTree"/> <OutputTree Name="AnalysisTree"/> </InputData> -->
 
-    <InputData Version="TTbar_SemiLeptonic_Mtt0000to0700_2018" Lumi="169042554.76" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
+    <InputData Version="TTbar_SemiLeptonic_Mtt0000to0700_UL18" Lumi="169042554.76" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
     &TTToSemiLeptonic_Mtt0000to0700; <InputTree Name="AnalysisTree"/> <OutputTree Name="AnalysisTree"/> </InputData>
 
-    <!-- <InputData Version="TTbar_Hadronic_Mtt0000to0700_2018" Lumi="126708342.91" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
+    <!-- <InputData Version="TTbar_Hadronic_Mtt0000to0700_UL18" Lumi="126708342.91" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
     &TTToHadronic_Mtt0000to0700; <InputTree Name="AnalysisTree"/> <OutputTree Name="AnalysisTree"/> </InputData>
 
-    <InputData Version="TTbar_Mtt0700to1000_2018" Lumi="311904071.33" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
+    <InputData Version="TTbar_Mtt0700to1000_UL18" Lumi="311904071.33" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
     &TT_Mtt0700to1000; <InputTree Name="AnalysisTree"/> <OutputTree Name="AnalysisTree"/> </InputData>
 
-    <InputData Version="TTbar_Mtt1000toInft_2018" Lumi="918549952.59" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
+    <InputData Version="TTbar_Mtt1000toInft_UL18" Lumi="918549952.59" Type="MC" NEventsMax="&NEVT;" Cacheable="False">
     &TT_Mtt1000toInft; <InputTree Name="AnalysisTree"/> <OutputTree Name="AnalysisTree"/> </InputData> -->
 
 <!-- ================================================================================================================================== -->


### PR DESCRIPTION
UHH2 takes dataset version from version name in config. Set to UL18 instead of 2018 for EOY.